### PR TITLE
feat(app): add forgotten flow and finalize current implementation

### DIFF
--- a/.github/prompts/implement.prompt.md
+++ b/.github/prompts/implement.prompt.md
@@ -92,11 +92,29 @@ Provide a summary:
 - Verification result (TypeScript build, Prisma generate, etc.)
 - List of changes implemented
 
-**Wait for the user to confirm** that the PR is ready to close (either by merging, reviewing, or other validation).
+**Wait for the user to confirm** that the PR is ready to close.
 
-## Step 7 — Set project item to "Done"
+## Step 7 — Close the implementation
 
-Once the user confirms, use `projects_write` (method `update_project_item`) with:
+Once the user confirms that the implementation is ready to close:
+
+1. Merge the PR.
+2. Switch back to `main` locally and update it:
+
+```sh
+git checkout main && git pull origin main
+```
+
+3. Delete the feature branch locally and remotely:
+
+```sh
+git branch -d <branch>
+git push origin --delete <branch>
+```
+
+## Step 8 — Set project item to "Done"
+
+After the PR is merged and the branch is deleted, use `projects_write` (method `update_project_item`) with:
 - `project_number`: `2`
 - `item_id`: the same item ID from Step 1.5
 - `updated_field`: `{"id": 271527944, "value": "98236657"}`
@@ -108,5 +126,7 @@ This sets the status to "Done" (`98236657`).
 After all steps, confirm:
 - Branch name
 - PR title, number, and URL
+- Whether the PR was merged
+- Whether the branch was deleted locally and remotely
 - Number of comments added to the issue
 - Verification result (TypeScript build, Prisma generate, etc.)

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,73 @@
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import Button from './Button'
+
+type ConfirmDialogProps = {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel: string
+  cancelLabel: string
+  onConfirm: () => void
+  onCancel: () => void
+  isConfirming?: boolean
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  isConfirming = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel} className="relative z-50">
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/30 transition duration-300 ease-out data-closed:opacity-0"
+      />
+
+      <div className="fixed inset-0 z-50 w-screen overflow-y-auto">
+        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <DialogPanel
+            transition
+            className="relative transform overflow-hidden rounded-2xl bg-card px-4 pb-4 pt-5 text-left shadow-xl ring-1 ring-gray-900/10 transition-all duration-300 ease-out data-closed:translate-y-4 data-closed:opacity-0 data-enter:sm:data-closed:translate-y-0 data-enter:sm:data-closed:scale-95 data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full sm:max-w-lg sm:p-6 dark:ring-white/10"
+          >
+            <div className="sm:flex sm:items-start">
+              <div className="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:size-10">
+                <ExclamationTriangleIcon aria-hidden="true" className="size-6 text-red-600 sm:size-5" />
+              </div>
+
+              <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                <DialogTitle as="h3" className="text-base font-semibold text-foreground">
+                  {title}
+                </DialogTitle>
+                <div className="mt-2">
+                  <p className="text-sm text-muted-foreground">{description}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-col-reverse gap-3 sm:mt-4 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={onCancel}>
+                {cancelLabel}
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                className="bg-destructive text-white hover:bg-destructive/90 focus-visible:outline-destructive"
+                onClick={onConfirm}
+                disabled={isConfirming}
+              >
+                {confirmLabel}
+              </Button>
+            </div>
+          </DialogPanel>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/HeaderNavigation.tsx
+++ b/frontend/src/components/HeaderNavigation.tsx
@@ -134,6 +134,16 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
               {t(item.labelKey)}
             </button>
           ))}
+          {isAuthenticated ? (
+            <>
+              <button type="button" onClick={() => onNavigate('/memorize')} className="cursor-pointer text-sm/6 font-semibold text-foreground">
+                {t('nav.memorize')}
+              </button>
+              <button type="button" onClick={() => onNavigate('/practice')} className="cursor-pointer text-sm/6 font-semibold text-foreground">
+                {t('nav.practice')}
+              </button>
+            </>
+          ) : null}
         </div>
         <div className="hidden lg:flex lg:flex-1 lg:justify-end lg:gap-x-6">
           <button
@@ -150,8 +160,6 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
               label={t('nav.myAccount')}
               items={[
                 { label: t('nav.viewAccount'), onClick: handleNavigateToMyAccount },
-                { label: t('nav.memorize'), onClick: () => onNavigate('/memorize') },
-                { label: t('nav.practice'), onClick: () => onNavigate('/practice') },
                 { label: t('nav.logout'), onClick: handleLogout },
               ]}
             />
@@ -196,6 +204,24 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
                     {t(item.labelKey)}
                   </button>
                 ))}
+                {isAuthenticated ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => { setMobileMenuOpen(false); onNavigate('/memorize') }}
+                      className="-mx-3 block rounded-full px-3 py-2 text-base/7 font-semibold text-foreground hover:bg-accent"
+                    >
+                      {t('nav.memorize')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setMobileMenuOpen(false); onNavigate('/practice') }}
+                      className="-mx-3 block rounded-full px-3 py-2 text-base/7 font-semibold text-foreground hover:bg-accent"
+                    >
+                      {t('nav.practice')}
+                    </button>
+                  </>
+                ) : null}
               </div>
               <div className="py-6">
                 <button
@@ -230,20 +256,6 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
                           className="block w-full rounded-full py-2 pr-3 pl-6 text-left text-sm/7 font-semibold text-foreground hover:bg-accent"
                         >
                           {t('nav.viewAccount')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => { setMobileMenuOpen(false); onNavigate('/memorize') }}
-                          className="block w-full rounded-full py-2 pr-3 pl-6 text-left text-sm/7 font-semibold text-foreground hover:bg-accent"
-                        >
-                          {t('nav.memorize')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => { setMobileMenuOpen(false); onNavigate('/practice') }}
-                          className="block w-full rounded-full py-2 pr-3 pl-6 text-left text-sm/7 font-semibold text-foreground hover:bg-accent"
-                        >
-                          {t('nav.practice')}
                         </button>
                         <button
                           type="button"

--- a/frontend/src/components/VersePlayer.tsx
+++ b/frontend/src/components/VersePlayer.tsx
@@ -10,6 +10,7 @@ import { apiFetch } from '../api/client'
 import { useTranslation } from '../i18n/LanguageContext'
 import Button from './Button'
 import CategoryBadge, { toBadgeColor } from './CategoryBadge'
+import ConfirmDialog from './ConfirmDialog'
 
 export type VersePlayerVerse = {
   id: string
@@ -55,6 +56,7 @@ export default function VersePlayer({ verses, mode }: VersePlayerProps) {
   const [persistingReviewVerseIds, setPersistingReviewVerseIds] = useState<Set<string>>(new Set())
   const [persistedReviews, setPersistedReviews] = useState<Record<string, PersistedReview>>({})
   const [reviewPersistError, setReviewPersistError] = useState<string | null>(null)
+  const [isForgottenDialogOpen, setIsForgottenDialogOpen] = useState(false)
 
   const currentVerse = verses[currentVerseIndex]
   const currentWords = useMemo(() => getWords(currentVerse.verse), [currentVerse.verse])
@@ -257,6 +259,57 @@ export default function VersePlayer({ verses, mode }: VersePlayerProps) {
     setCompletionStatus(null)
   }
 
+  const markCurrentVerseAsForgotten = async () => {
+    if (mode === 'practice') {
+      return
+    }
+
+    if (persistingReviewVerseIds.has(currentVerse.id)) {
+      return
+    }
+
+    setPersistingReviewVerseIds((prev) => new Set(prev).add(currentVerse.id))
+    setReviewPersistError(null)
+
+    try {
+      const result = await apiFetch<{
+        verse: {
+          id: string
+          leitnerLevel: number
+          learningState: 'LEARNING' | 'MASTERED'
+          dueAt: string
+        }
+      }>(`/account/verses/${currentVerse.id}/review`, {
+        method: 'POST',
+        body: JSON.stringify({ success: false }),
+      })
+
+      setPersistedReviewVerseIds((prev) => new Set(prev).add(currentVerse.id))
+      setPersistedReviews((prev) => ({
+        ...prev,
+        [currentVerse.id]: {
+          leitnerLevel: result.verse.leitnerLevel,
+          learningState: result.verse.learningState,
+          dueAt: result.verse.dueAt,
+        },
+      }))
+
+      setIsForgottenDialogOpen(false)
+      if (currentVerseIndex < verses.length - 1) {
+        nextVerse()
+      }
+    } catch {
+      setReviewPersistError(t('versePlayer.persistError'))
+      setIsForgottenDialogOpen(false)
+    } finally {
+      setPersistingReviewVerseIds((prev) => {
+        const next = new Set(prev)
+        next.delete(currentVerse.id)
+        return next
+      })
+    }
+  }
+
   const toggleText = () => {
     setShowText((prev) => !prev)
   }
@@ -364,6 +417,19 @@ export default function VersePlayer({ verses, mode }: VersePlayerProps) {
             </Button>
           </div>
         ) : null}
+
+        {completionStatus === null && mode === 'memorize' && !showText ? (
+          <div className="flex flex-wrap justify-center gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setIsForgottenDialogOpen(true)}
+              disabled={persistingReviewVerseIds.has(currentVerse.id)}
+            >
+              {t('versePlayer.forgottenButton')}
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       <div className="mt-6 flex items-center justify-between">
@@ -390,6 +456,19 @@ export default function VersePlayer({ verses, mode }: VersePlayerProps) {
           <ArrowRightIcon className="size-4" />
         </Button>
       </div>
+
+      <ConfirmDialog
+        open={isForgottenDialogOpen}
+        title={t('versePlayer.forgottenDialogTitle')}
+        description={t('versePlayer.forgottenDialogDescription')}
+        confirmLabel={t('versePlayer.forgottenConfirm')}
+        cancelLabel={t('versePlayer.forgottenCancel')}
+        onCancel={() => setIsForgottenDialogOpen(false)}
+        onConfirm={() => {
+          void markCurrentVerseAsForgotten()
+        }}
+        isConfirming={persistingReviewVerseIds.has(currentVerse.id)}
+      />
     </section>
   )
 }

--- a/frontend/src/i18n/translations/en.ts
+++ b/frontend/src/i18n/translations/en.ts
@@ -200,6 +200,11 @@ const en = {
   'versePlayer.reviewToday': 'It will be reviewed again today.',
   'versePlayer.reviewTomorrow': 'It will be reviewed again tomorrow.',
   'versePlayer.reviewOn': 'It will be reviewed again on {date}.',
+  'versePlayer.forgottenButton': 'Forgotten',
+  'versePlayer.forgottenDialogTitle': 'Mark verse as forgotten?',
+  'versePlayer.forgottenDialogDescription': 'This verse will be moved back to level 1 and scheduled for more frequent review.',
+  'versePlayer.forgottenConfirm': 'Yes, reset to level 1',
+  'versePlayer.forgottenCancel': 'Cancel',
 
   // Language
   'language.en': 'English',

--- a/frontend/src/i18n/translations/es.ts
+++ b/frontend/src/i18n/translations/es.ts
@@ -202,6 +202,11 @@ const es: Record<TranslationKey, string> = {
   'versePlayer.reviewToday': 'Se repasará de nuevo hoy.',
   'versePlayer.reviewTomorrow': 'Se repasará de nuevo mañana.',
   'versePlayer.reviewOn': 'Se repasará de nuevo el {date}.',
+  'versePlayer.forgottenButton': 'Olvidado',
+  'versePlayer.forgottenDialogTitle': '¿Marcar versículo como olvidado?',
+  'versePlayer.forgottenDialogDescription': 'Este versículo volverá al nivel 1 y se programará para repasos más frecuentes.',
+  'versePlayer.forgottenConfirm': 'Sí, volver al nivel 1',
+  'versePlayer.forgottenCancel': 'Cancelar',
 
   // Language
   'language.en': 'English',


### PR DESCRIPTION
## Summary
- add the Forgotten flow in memorize mode with a reusable confirmation dialog
- expose Memorize and Practice as direct navigation entries for authenticated users
- update the implement prompt so closing an implementation also merges the PR, updates main, and deletes the branch

## Checklist
- [x] added reusable `ConfirmDialog` with Headless UI warning pattern
- [x] wired `VersePlayer` forgotten flow to submit `success: false`
- [x] added EN/ES i18n keys for the new dialog and button
- [x] moved Memorize and Practice into direct authenticated navigation
- [x] updated the implement prompt closing steps
- [x] validated TypeScript in frontend and backend

Closes #11