### PR TITLE
Add Study Again reset endpoint & UI

### DIFF
--- a/backend/src/routes/account.ts
+++ b/backend/src/routes/account.ts
@@ -246,3 +246,60 @@ accountRouter.post("/verses/:verseId/review", async (request, response) => {
 
   response.json({ verse: updated });
 });
+
+accountRouter.post("/verses/:verseId/study-again", async (request, response) => {
+  const session = await auth.api.getSession({
+    headers: request.headers as never
+  });
+
+  if (!session?.user?.id) {
+    response.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const userId = session.user.id;
+  const verseId = request.params.verseId;
+
+  const verse = await prisma.verse.findFirst({
+    where: {
+      id: verseId,
+      userId
+    },
+    select: {
+      id: true,
+      learningState: true
+    }
+  });
+
+  if (!verse) {
+    response.status(404).json({ error: "Verse not found" });
+    return;
+  }
+
+  if (verse.learningState !== "MASTERED") {
+    response.status(400).json({ error: "Only mastered verses can be reset" });
+    return;
+  }
+
+  const now = new Date();
+  const updated = await prisma.verse.update({
+    where: { id: verse.id },
+    data: {
+      leitnerLevel: 1,
+      learningState: "LEARNING",
+      dueAt: now,
+      masteredAt: null,
+      resetCount: { increment: 1 }
+    },
+    select: {
+      id: true,
+      leitnerLevel: true,
+      learningState: true,
+      dueAt: true,
+      masteredAt: true,
+      resetCount: true
+    }
+  });
+
+  response.json({ verse: updated });
+});

--- a/frontend/src/i18n/translations/en.ts
+++ b/frontend/src/i18n/translations/en.ts
@@ -136,6 +136,9 @@ const en = {
   'myAccount.success': 'success',
   'myAccount.fail': 'fail',
   'myAccount.resets': 'Resets',
+  'myAccount.studyAgain': 'Study Again',
+  'myAccount.studyingAgain': 'Resetting...',
+  'myAccount.studyAgainError': 'Unable to reset this verse right now. Please try again.',
 
   // My Verses
   'myVerses.title': 'My verses',

--- a/frontend/src/i18n/translations/es.ts
+++ b/frontend/src/i18n/translations/es.ts
@@ -138,6 +138,9 @@ const es: Record<TranslationKey, string> = {
   'myAccount.success': 'éxito',
   'myAccount.fail': 'fallo',
   'myAccount.resets': 'Reinicios',
+  'myAccount.studyAgain': 'Estudiar de nuevo',
+  'myAccount.studyingAgain': 'Reiniciando...',
+  'myAccount.studyAgainError': 'No se pudo reiniciar este versículo. Por favor, inténtalo de nuevo.',
 
   // My Verses
   'myVerses.title': 'Mis versículos',

--- a/frontend/src/pages/MyAccount.tsx
+++ b/frontend/src/pages/MyAccount.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { apiFetch } from '../api/client'
+import Button from '../components/Button'
 import PageHeader from '../components/PageHeader'
 import PageShell from '../components/PageShell'
 import { useTranslation } from '../i18n/LanguageContext'
@@ -54,6 +55,8 @@ export default function MyAccount() {
   const { t } = useTranslation()
   const [accountData, setAccountData] = useState<AuthSessionResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [resettingVerseId, setResettingVerseId] = useState<string | null>(null)
+  const [studyAgainError, setStudyAgainError] = useState<string | null>(null)
 
   const levelSummary = useMemo(() => {
     const levels = Array.from({ length: 7 }, (_, index) => ({
@@ -88,6 +91,52 @@ export default function MyAccount() {
 
     void loadSession()
   }, [])
+
+  const handleStudyAgain = async (verseId: string) => {
+    setResettingVerseId(verseId)
+    setStudyAgainError(null)
+
+    try {
+      const response = await apiFetch<{
+        verse: {
+          id: string
+          leitnerLevel: number
+          learningState: 'LEARNING' | 'MASTERED'
+          dueAt: string
+          masteredAt: string | null
+          resetCount: number
+        }
+      }>(`/account/verses/${encodeURIComponent(verseId)}/study-again`, {
+        method: 'POST',
+      })
+
+      setAccountData((current) => {
+        if (!current) {
+          return current
+        }
+
+        return {
+          ...current,
+          verses: current.verses.map((verse) =>
+            verse.id === response.verse.id
+              ? {
+                  ...verse,
+                  leitnerLevel: response.verse.leitnerLevel,
+                  learningState: response.verse.learningState,
+                  dueAt: response.verse.dueAt,
+                  masteredAt: response.verse.masteredAt,
+                  resetCount: response.verse.resetCount,
+                }
+              : verse,
+          ),
+        }
+      })
+    } catch {
+      setStudyAgainError(t('myAccount.studyAgainError'))
+    } finally {
+      setResettingVerseId(null)
+    }
+  }
 
   if (isLoading) {
     return (
@@ -180,6 +229,7 @@ export default function MyAccount() {
             <h2 className="text-lg font-semibold text-foreground">{t('myAccount.verses')}</h2>
             <span className="text-sm text-muted-foreground">{accountData.verses.length} {t('myAccount.total')}</span>
           </div>
+          {studyAgainError ? <p className="mt-3 text-sm text-destructive">{studyAgainError}</p> : null}
           {accountData.verses.length === 0 ? (
             <p className="mt-3 text-sm text-muted-foreground">{t('myAccount.noVerses')}</p>
           ) : (
@@ -197,6 +247,20 @@ export default function MyAccount() {
                   <p className="mt-1 text-xs text-muted-foreground">
                     {t('myAccount.reviews')}: {verse.totalReviews} {t('myAccount.total')} ({verse.successfulReviews} {t('myAccount.success')} / {verse.failedReviews} {t('myAccount.fail')}) · {t('myAccount.resets')}: {verse.resetCount}
                   </p>
+                  {verse.learningState === 'MASTERED' ? (
+                    <div className="mt-3">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        disabled={resettingVerseId === verse.id}
+                        onClick={() => {
+                          void handleStudyAgain(verse.id)
+                        }}
+                      >
+                        {resettingVerseId === verse.id ? t('myAccount.studyingAgain') : t('myAccount.studyAgain')}
+                      </Button>
+                    </div>
+                  ) : null}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
Add a backend POST /account/verses/:verseId/study-again endpoint to let users reset a MASTERED verse back to learning. The endpoint verifies the session and ownership, ensures the verse is MASTERED, then updates leitnerLevel to 1, learningState to LEARNING, dueAt to now, clears masteredAt, and increments resetCount, returning the updated verse.

On the frontend, add translations (en/es) for study-again labels and errors, import a Button into MyAccount, and implement handleStudyAgain to call the new endpoint. The UI shows a "Study Again" button for MASTERED verses, displays a loading label while resetting, handles errors with a visible message, and updates accountData with the returned verse state.

<img width="1453" height="532" alt="image" src="https://github.com/user-attachments/assets/7f475167-3999-4c24-9b93-9f2dc0765661" />