### PR TITLE
Fix email sign-in and persist database sessions

### DIFF
--- a/src/lib/auth-csrf.ts
+++ b/src/lib/auth-csrf.ts
@@ -9,6 +9,7 @@ interface ValidateAuthCsrfTokenOptions {
 }
 
 const CSRF_COOKIE_NAMES = [
+  "__Host-next-auth.csrf-token",
   "__Secure-next-auth.csrf-token",
   "next-auth.csrf-token",
 ] as const;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -79,7 +79,11 @@ function localizeAuthRedirect(url: string, baseUrl: string) {
 
 export const authOptions: NextAuthOptions = {
   adapter: hardenAdapter(PrismaAdapter(db)),
-  session: { strategy: "database" },
+  session: {
+    strategy: "database",
+    maxAge: 30 * 24 * 60 * 60,
+    updateAge: 24 * 60 * 60,
+  },
   pages: {
     error: "/login/error",
   },

--- a/tests/unit/auth-csrf.test.ts
+++ b/tests/unit/auth-csrf.test.ts
@@ -13,7 +13,11 @@ const token = "csrf-token-value";
 const hash = createHash("sha256").update(`${token}${secret}`).digest("hex");
 
 describe("Auth.js CSRF prevalidation", () => {
-  it.each(["next-auth.csrf-token", "__Secure-next-auth.csrf-token"])(
+  it.each([
+    "next-auth.csrf-token",
+    "__Secure-next-auth.csrf-token",
+    "__Host-next-auth.csrf-token",
+  ])(
     "accepts a signed double-submit token from %s",
     (cookieName) => {
       expect(

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -80,6 +80,16 @@ describe("authOptions", () => {
     mocks.deleteMany.mockResolvedValue({ count: 1 });
   });
 
+  it("keeps database sessions for 30 days and refreshes them daily", async () => {
+    const { authOptions } = await import("@/lib/auth");
+
+    expect(authOptions.session).toEqual({
+      strategy: "database",
+      maxAge: 30 * 24 * 60 * 60,
+      updateAge: 24 * 60 * 60,
+    });
+  });
+
   it("does not enable email auth from SMTP configuration alone", async () => {
     mocks.smtp = { server: { host: "smtp.example.test" }, from: "noreply@example.test" };
 


### PR DESCRIPTION
## Summary
- accept the `__Host-next-auth.csrf-token` cookie emitted in production so valid email sign-in requests are not rejected with 403
- keep opaque, revocable database sessions for 30 days and refresh their database expiry once per day
- add regression coverage for the production CSRF cookie and session policy

## Validation
- `pnpm test` (236 passed, 20 skipped)
- `pnpm typecheck`
- `pnpm lint` (no errors; 4 existing warnings)