### PR TITLE
Trigger production deploy after Dependabot merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
 
 concurrency:
@@ -17,6 +22,12 @@ permissions:
 jobs:
   deploy:
     name: Deploy with Docker Compose
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on:
       - self-hosted
       - Linux


### PR DESCRIPTION
## Summary

Ensure production deployment runs after Dependabot auto-merges a pull request into `main`.

## Changes

- Listen for closed pull requests targeting `main`.
- Run the deploy job only when the pull request was merged by Dependabot.
- Keep the existing `push` trigger for normal `main` updates without duplicate deployments.

## Validation

- YAML parsing passed.
- VS Code reports no errors for the workflow.
- `git diff --check` passed.