### PR TITLE
Fix SMTP transport check in runtime image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,44 +170,19 @@ jobs:
           exit 1
 
       - name: Verify SMTP transport
-        env:
-          PROJECT_NAME: ${{ vars.PROJECT_NAME }}
-          APP_DOMAIN: ${{ vars.APP_DOMAIN }}
         run: |
           cd "$DEPLOY_DIR"
           echo "Verifying SMTP transport from the production app container..."
-          docker compose -f docker-compose.prod.yml exec -T app node --input-type=module -e '
-            import nodemailer from "nodemailer";
-
-            const port = Number(process.env.SMTP_PORT || 587);
-            const transport = nodemailer.createTransport({
-              host: process.env.SMTP_HOST,
-              port,
-              secure: process.env.SMTP_SECURE === "true" || port === 465,
-              auth: {
-                user: process.env.SMTP_USER,
-                pass: process.env.SMTP_PASSWORD,
-              },
-              connectionTimeout: 10000,
-              greetingTimeout: 10000,
-              socketTimeout: 10000,
-            });
-
-            try {
-              await transport.verify();
-              console.log("SMTP transport verified.");
-            } catch (error) {
-              const details = error && typeof error === "object" ? error : {};
-              console.error(JSON.stringify({
-                code: "code" in details ? details.code : undefined,
-                responseCode: "responseCode" in details ? details.responseCode : undefined,
-                command: "command" in details ? details.command : undefined,
-                errno: "errno" in details ? details.errno : undefined,
-              }));
-              process.exitCode = 1;
-            } finally {
-              transport.close();
+          docker compose -f docker-compose.prod.yml exec -T app sh -eu -c '
+            user_b64="$(printf %s "$SMTP_USER" | openssl base64 -A)"
+            password_b64="$(printf %s "$SMTP_PASSWORD" | openssl base64 -A)"
+            response="$(printf "EHLO versmedit.com\\r\\nAUTH LOGIN\\r\\n%s\\r\\n%s\\r\\nQUIT\\r\\n" "$user_b64" "$password_b64" | openssl s_client -connect "$SMTP_HOST:$SMTP_PORT" -servername "$SMTP_HOST" -quiet 2>&1)"
+            printf "%s\\n" "$response" | sed -E "s/^[[:space:]]*[0-9]{3}[- ]/SMTP response: /" | tail -20
+            printf "%s\\n" "$response" | grep -q "235" || {
+              echo "SMTP authentication failed or the server rejected the session."
+              exit 1
             }
+            echo "SMTP transport verified."
           '
 
       - name: Prune old images


### PR DESCRIPTION
## Summary

Fix the production SMTP diagnostic to use the `openssl` binary available in the standalone runtime image.

## Context

The previous deploy check failed before reaching SMTP because `nodemailer` is not available as a top-level runtime package in the standalone image. This version verifies TLS and `AUTH LOGIN` directly and reports the server response without exposing credentials.

## Validation

- YAML parsing passed.
- VS Code reports no errors.
- `git diff --check` passed.