### PR TITLE
Use Node 24 LTS and deploy only from main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
           - minor
           - patch
 
-  # Base images in the Dockerfile (e.g. node:26-slim).
+  # Base images in the Dockerfile (e.g. node:24-slim).
   - package-ecosystem: docker
     directory: /docker
     schedule:

--- a/.github/workflows/backup-restore-verify.yml
+++ b/.github/workflows/backup-restore-verify.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 26
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          # Matches the runtime image (node:26-slim) used in docker/Dockerfile.
-          node-version: 26
+          # Matches the runtime image (node:24-slim) used in docker/Dockerfile.
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
   workflow_dispatch:
 
 concurrency:
@@ -22,13 +17,6 @@ permissions:
 jobs:
   deploy:
     name: Deploy with Docker Compose
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on:
       - self-hosted
       - Linux

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -19,7 +19,7 @@
   during /speckit.plan.
 -->
 
-**Language/Version**: TypeScript 5.x on Node.js 26
+**Language/Version**: TypeScript 5.x on Node.js 24 LTS
 
 **Package Manager**: pnpm
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The non-negotiable engineering principles for this architecture live in
 
 ## Stack
 
-- **Language / runtime**: TypeScript on Node.js 26 · **pnpm**
+- **Language / runtime**: TypeScript on Node.js 24 LTS · **pnpm**
 - **Framework**: Next.js (App Router) + React — one full-stack `app` (UI, SSR, API routes, Server Actions, auth)
 - **Database**: PostgreSQL via Prisma 7 (driver adapter)
 - **Validation**: Zod · **Auth**: NextAuth v4 stable · **Email**: Brevo or Mailjet over HTTPS
@@ -20,7 +20,7 @@ The non-negotiable engineering principles for this architecture live in
 
 ## Requirements
 
-- Node.js 26 + pnpm (`corepack enable`)
+- Node.js 24 LTS + pnpm (`corepack enable`)
 - Docker + Docker Compose (for the local database)
 
 ## Getting started (development)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Base image is Debian-slim (works on ARM64/Raspberry Pi and amd64/VPS) and
 # includes OpenSSL for Prisma. Build and runtime share the same base so the
 # Prisma engine matches the runtime platform (constitution Principle IV).
-FROM node:26-slim@sha256:715e55e4b84e4bb0ff48e49b398a848f08e55daed8eb6a0ea1839ae53bc57583 AS base
+FROM node:24-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Non-interactive corepack: let it fetch the pinned pnpm without prompting.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fullstack-webapp-template",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": ">=24.0.0 <25.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@11.13.0",
+  "engines": {
+    "node": ">=24.0.0 <25.0.0"
+  },
   "scripts": {
     "predev": "docker compose up -d --wait db && pnpm db:deploy && NODE_ENV=development node prisma/seed.mjs",
     "dev": "next dev",
@@ -52,7 +55,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.4",
-    "@types/node": "^26",
+    "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@hono/node-server': 1.19.13
+  '@types/node': 24.13.3
   deepmerge-ts: 8.0.0
   fast-uri: 3.1.5
   nanoid: 3.3.18
@@ -25,7 +26,7 @@ importers:
         version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@next-auth/prisma-adapter':
         specifier: 1.0.7
-        version: 1.0.7(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 1.0.7(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@prisma/adapter-pg':
         specifier: ^7.9.1
         version: 7.9.1
@@ -46,13 +47,13 @@ importers:
         version: 1.31.0(react@19.2.8)
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-auth:
         specifier: 4.24.15
-        version: 4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.2
-        version: 4.13.2(@swc/helpers@0.5.23)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+        version: 4.13.2(@swc/helpers@0.5.23)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -97,8 +98,8 @@ importers:
         specifier: ^14.6.4
         version: 14.6.4(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^26
-        version: 26.2.0
+        specifier: 24.13.3
+        version: 24.13.3
       '@types/react':
         specifier: ^19
         version: 19.2.18
@@ -137,7 +138,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
 
 packages:
 
@@ -1419,8 +1420,8 @@ packages:
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
-  '@types/node@26.2.0':
-    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -4247,8 +4248,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -4316,7 +4317,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': 24.13.3
       '@vitejs/devtools': ^0.3.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
@@ -4361,7 +4362,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': 24.13.3
       '@vitest/browser-playwright': 4.1.10
       '@vitest/browser-preview': 4.1.10
       '@vitest/browser-webdriverio': 4.1.10
@@ -5096,10 +5097,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
-      next-auth: 4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next-auth: 4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@next/env@16.2.11': {}
 
@@ -5671,13 +5672,13 @@ snapshots:
 
   '@types/lodash@4.17.25': {}
 
-  '@types/node@26.2.0':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 8.3.0
+      undici-types: 7.18.2
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 26.2.0
+      '@types/node': 24.13.3
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -5941,7 +5942,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -5952,13 +5953,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4(@types/node@26.2.0)(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -7699,13 +7700,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next-auth@4.24.15(patch_hash=3c3a4ffa2aa2e13c0aba3484cf6b701cb2a3839b5891c7b2740d89cac5a2b452)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.24.3
@@ -7716,14 +7717,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.2: {}
 
-  next-intl@4.13.2(@swc/helpers@0.5.23)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
+  next-intl@4.13.2(@swc/helpers@0.5.23)(next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
       icu-minify: 4.13.2
       negotiator: 1.0.0
-      next: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.2
       po-parser: 2.1.1
       react: 19.2.8
@@ -7738,7 +7739,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
@@ -7758,7 +7759,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
       '@playwright/test': 1.62.1
-      sharp: 0.35.3(@types/node@26.2.0)
+      sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -8435,7 +8436,7 @@ snapshots:
       - supports-color
       - typescript
 
-  sharp@0.35.3(@types/node@26.2.0):
+  sharp@0.35.3(@types/node@24.13.3):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -8466,7 +8467,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 26.2.0
+      '@types/node': 24.13.3
     optional: true
 
   shebang-command@2.0.0:
@@ -8774,7 +8775,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@8.3.0: {}
+  undici-types@7.18.2: {}
 
   undici@7.28.0: {}
 
@@ -8845,7 +8846,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0):
+  vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -8853,14 +8854,14 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@26.2.0)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -8877,10 +8878,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@26.2.0)(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 29.1.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ allowBuilds:
 
 overrides:
   '@hono/node-server': 1.19.13
+  '@types/node': 24.13.3
   deepmerge-ts: 8.0.0
   fast-uri: 3.1.5
   nanoid: 3.3.18

--- a/specs/20260719-email-magic-link-login/plan.md
+++ b/specs/20260719-email-magic-link-login/plan.md
@@ -19,7 +19,7 @@ localized design and single-field flow without schema, migration, container, or 
 
 ## Technical Context
 
-**Language/Version**: TypeScript 5.x on Node.js 26
+**Language/Version**: TypeScript 5.x on Node.js 24 LTS
 
 **Package Manager**: pnpm
 

--- a/specs/20260719-email-magic-link-login/quickstart.md
+++ b/specs/20260719-email-magic-link-login/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 26 and pnpm 11
+- Node.js 24 LTS and pnpm 11
 - Docker Compose
 - Local `.env` with valid development database, `AUTH_SECRET` (32+ characters), canonical
   `NEXTAUTH_URL`, and SMTP settings when manually exercising real delivery

--- a/specs/20260720-account-profile-page/plan.md
+++ b/specs/20260720-account-profile-page/plan.md
@@ -20,7 +20,7 @@ integration, accessibility, responsive, and standalone-production Playwright tes
 
 ## Technical Context
 
-**Language/Version**: TypeScript 5.x on Node.js 26 (Docker build/runtime)
+**Language/Version**: TypeScript 5.x on Node.js 24 LTS (Docker build/runtime)
 
 **Package Manager**: pnpm
 

--- a/specs/20260720-account-profile-page/quickstart.md
+++ b/specs/20260720-account-profile-page/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 26 and the repository-pinned pnpm version
+- Node.js 24 LTS and the repository-pinned pnpm version
 - Docker Desktop/Engine with Compose
 - Local `.env` populated from `.env.example` with valid development values
 - Current branch: `20260720-account-profile-page`

--- a/specs/20260818-signup-page/plan.md
+++ b/specs/20260818-signup-page/plan.md
@@ -21,7 +21,7 @@ session.
 
 **Language/Version**: TypeScript 5.x on Node.js 24 LTS
 
-**Package Manager**: pnpm 11.13.0
+**Package Manager**: pnpm 11.22.0
 
 **Primary Dependencies**: Next.js 16.2 App Router + React 19.2, Tailwind CSS 4,
 next-intl 4.13, Prisma 7.8, Zod 4.4, patched NextAuth 4.24.14 with the Prisma adapter,

--- a/specs/20260818-signup-page/plan.md
+++ b/specs/20260818-signup-page/plan.md
@@ -19,7 +19,7 @@ session.
 
 ## Technical Context
 
-**Language/Version**: TypeScript 5.x on Node.js 26
+**Language/Version**: TypeScript 5.x on Node.js 24 LTS
 
 **Package Manager**: pnpm 11.13.0
 

--- a/specs/20260818-signup-page/quickstart.md
+++ b/specs/20260818-signup-page/quickstart.md
@@ -6,7 +6,7 @@ are defined in [contracts/openapi.yaml](./contracts/openapi.yaml).
 
 ## Prerequisites
 
-- Node.js 26 and pnpm 11.13.0.
+- Node.js 24 LTS and pnpm 11.13.0.
 - Docker with Compose.
 - Existing local development environment values, including `AUTH_SECRET`.
 - User-authorized development dummy English, Spanish, and Catalan Terms and Privacy Notice content,

--- a/specs/20260818-signup-page/quickstart.md
+++ b/specs/20260818-signup-page/quickstart.md
@@ -6,7 +6,7 @@ are defined in [contracts/openapi.yaml](./contracts/openapi.yaml).
 
 ## Prerequisites
 
-- Node.js 24 LTS and pnpm 11.13.0.
+- Node.js 24 LTS and pnpm 11.22.0.
 - Docker with Compose.
 - Existing local development environment values, including `AUTH_SECRET`.
 - User-authorized development dummy English, Spanish, and Catalan Terms and Privacy Notice content,

--- a/specs/20260819-http-email-providers/plan.md
+++ b/specs/20260819-http-email-providers/plan.md
@@ -25,7 +25,7 @@ change. Remove Nodemailer and SMTP wiring after development and production smoke
   reason to differ; fill feature-specific values during /speckit.plan.
 -->
 
-**Language/Version**: TypeScript 5.x on Node.js 26
+**Language/Version**: TypeScript 5.x on Node.js 24 LTS
 
 **Package Manager**: pnpm
 

--- a/specs/20260819-http-email-providers/quickstart.md
+++ b/specs/20260819-http-email-providers/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 26 and pnpm 11
+- Node.js 24 LTS and pnpm 11
 - Docker with Docker Compose
 - PostgreSQL available through the repository Compose stack
 - For real smoke checks only: one verified sender and valid credentials for the selected provider, plus controlled login/signup mailboxes

--- a/specs/20260819-http-email-providers/research.md
+++ b/specs/20260819-http-email-providers/research.md
@@ -5,7 +5,7 @@
 
 ## 1. HTTP Client and Dependency Strategy
 
-**Decision**: Use Node.js 26's built-in WHATWG `fetch`, `Headers`, and `AbortSignal.timeout()` through an injected server-only request function. Do not add Brevo, Mailjet, Axios, Undici, or retry libraries.
+**Decision**: Use Node.js 24 LTS's built-in WHATWG `fetch`, `Headers`, and `AbortSignal.timeout()` through an injected server-only request function. Do not add Brevo, Mailjet, Axios, Undici, or retry libraries.
 
 **Rationale**: Node documents global `fetch` as stable and backed by Undici, and `AbortSignal.timeout()` is available natively. The feature needs one JSON POST and one recipient-independent JSON GET per provider, with no proxy, custom dispatcher, streaming upload, or retry requirement. An injected request function gives unit and integration tests a controlled fake HTTP boundary without a runtime URL override.
 


### PR DESCRIPTION
## Summary

- remove the redundant `pull_request: closed` deployment trigger so merges deploy only from the resulting push to `main`
- align CI, backup verification, and production Docker with Prisma-supported Node 24 LTS
- pin the multi-architecture `node:24-slim` image digest and enforce Node 24 through package engines
- align direct and transitive Node typings on 24.13.3
- update repository documentation, quickstarts, plans, and templates to declare Node 24 LTS

## Validation

- dependency installation under Node 24 completes without Prisma's unsupported-version warning
- Prisma 7.9.1 runs locally on Node 24.16.0
- ARM64 migrator image runs Prisma 7.9.1 on Node 24.19.0
- complete production runner image builds and reports Node 24.19.0
- GitHub Actions workflow syntax and deployment trigger assertions pass
- Spec Kit compliance hook passes for all feature specifications
- lint and TypeScript checks pass
- 498 tests pass with coverage thresholds satisfied
