### PR TITLE
Ignore major Node.js updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Dependabot cannot identify the Node.js LTS channel. Keep major runtime
+    # upgrades coordinated with package engines, CI, and deployment targets.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary
- ignore semver-major Node.js image updates in Dependabot
- keep runtime upgrades coordinated with package engines, CI, and deployment targets

## Validation
- parsed `.github/dependabot.yml` successfully with Ruby YAML
- `git diff --check origin/main...HEAD`